### PR TITLE
feat(typescript): learn type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ function combine(
   input2: number | string,
   resultConversion: "as-nunmber" | "as-string"
 )
+
+---
+動画22：型エイリアス
+自分自身の型を設定
+型の名前を説明的にし可読性を上げる
+
+一番上で一回定義すればいいので再利用性も高い
+例）type 型の名前 = まとめたい型

--- a/app.ts
+++ b/app.ts
@@ -1,7 +1,10 @@
+type Combinable = number | string;
+type ComversionDescriptor = 'as-number' | 'as-string';
+
 function combine(
-  input1: number | string,
-  input2: number | string,
-  resultConversion: "as-number" | "as-string"
+  input1: Combinable,
+  input2: Combinable,
+  resultConversion: ComversionDescriptor,
 ) {
   let result;
 


### PR DESCRIPTION
## Summary
• Learn TypeScript type aliases functionality
• Add type definitions for Combinable and ComversionDescriptor
• Update function parameters to use custom types for better readability

## Changes
- Add `type Combinable = number | string;`
- Add `type ComversionDescriptor = 'as-number' | 'as-string';`
- Update combine function to use custom types
- Add learning notes to README.md

## Test plan
- [x] Code compiles without TypeScript errors
- [x] Type definitions work correctly
- [x] Documentation updated with learning notes

🤖 Generated with [Claude Code](https://claude.ai/code)